### PR TITLE
Update terminology in New Session and Complete Profile pages for cons…

### DIFF
--- a/src/app/dashboard/new-session/page.tsx
+++ b/src/app/dashboard/new-session/page.tsx
@@ -33,7 +33,7 @@ export default function NewSessionPage() {
 
   const handleSearch = () => {
     if (!documentNumber.trim()) {
-      usePatientStore.setState({ error: 'Por favor ingrese un número de documento' });
+      usePatientStore.setState({ error: 'Por favor ingrese un número de DNI' });
       return;
     }
     searchPatient(documentNumber);
@@ -89,7 +89,7 @@ export default function NewSessionPage() {
               type="text"
               value={documentNumber}
               onChange={(e) => setDocumentNumber(e.target.value)}
-              placeholder="Ingrese número de documento"
+              placeholder="Ingrese número de DNI"
               className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-primary focus:outline-none focus:ring-primary sm:text-sm"
             />
             <button

--- a/src/app/profile/complete-profile/page.tsx
+++ b/src/app/profile/complete-profile/page.tsx
@@ -205,7 +205,7 @@ export default function CompleteProfile() {
               </div>
               <div>
                 <label htmlFor="document_number" className="block text-sm font-medium text-gray-700">
-                  Número de Documento
+                  DNI
                 </label>
                 <input
                   type="text"
@@ -252,7 +252,7 @@ export default function CompleteProfile() {
               </div>
               <div>
                 <label htmlFor="license" className="block text-sm font-medium text-gray-700">
-                  Número de Licencia
+                  Número de Licencia (CMP)
                 </label>
                 <input
                   type="text"


### PR DESCRIPTION
This pull request includes changes to the `NewSessionPage` and `CompleteProfile` components to update the terminology used for document numbers and licenses. The most important changes include updating the placeholder and error messages for document numbers and adjusting the labels for document numbers and licenses.

Updates to terminology:

* [`src/app/dashboard/new-session/page.tsx`](diffhunk://#diff-46574112520d914c7a64b4371660b144499bcd6e607753ad2f31b69b69b5dc1fL36-R36): Changed error message from 'número de documento' to 'número de DNI' in the `handleSearch` function.
* [`src/app/dashboard/new-session/page.tsx`](diffhunk://#diff-46574112520d914c7a64b4371660b144499bcd6e607753ad2f31b69b69b5dc1fL92-R92): Updated placeholder text from 'Ingrese número de documento' to 'Ingrese número de DNI'.
* [`src/app/profile/complete-profile/page.tsx`](diffhunk://#diff-4d62bed4857bd4c09ac2d8a5df0f46b474584938b561b7192961db02fe10330fL208-R208): Changed label from 'Número de Documento' to 'DNI'.
* [`src/app/profile/complete-profile/page.tsx`](diffhunk://#diff-4d62bed4857bd4c09ac2d8a5df0f46b474584938b561b7192961db02fe10330fL255-R255): Updated label from 'Número de Licencia' to 'Número de Licencia (CMP)'.…istency and clarity