### PR TITLE
feat: add status badge types for past medical history, family history…

### DIFF
--- a/src/components/session/recordings/recordings-list.tsx
+++ b/src/components/session/recordings/recordings-list.tsx
@@ -264,6 +264,21 @@ export const RecordingsList: React.FC<RecordingsListProps> = ({
                   <span className="w-2 h-2 bg-violet-500 rounded-full mr-2"></span>
                   Procedimientos
                 </>
+              ) : type === 'past_medical_history' ? (
+                <>
+                  <span className="w-2 h-2 bg-amber-500 rounded-full mr-2"></span>
+                  Antecedentes Médicos
+                </>
+              ) : type === 'family_history' ? (
+                <>
+                  <span className="w-2 h-2 bg-emerald-500 rounded-full mr-2"></span>
+                  Antecedentes Familiares
+                </>
+              ) : type === 'vital_sign' ? (
+                <>
+                  <span className="w-2 h-2 bg-cyan-500 rounded-full mr-2"></span>
+                  Signos Vitales
+                </>
               ) : (
                 <>
                   <span className="w-2 h-2 bg-neutral-500 rounded-full mr-2"></span>


### PR DESCRIPTION
This pull request introduces new types to the `RecordingsList` component in `src/components/session/recordings/recordings-list.tsx`. These changes enhance the UI by adding different colored indicators for various medical history categories.

Changes to `RecordingsList` component:

* Added new type `past_medical_history` with an amber indicator and label "Antecedentes Médicos".
* Added new type `family_history` with an emerald indicator and label "Antecedentes Familiares".
* Added new type `vital_sign` with a cyan indicator and label "Signos Vitales".…, and vital signs